### PR TITLE
Chunked encoding

### DIFF
--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -65,7 +65,7 @@ func main() {
 			status = response.StatusInternalServerError
 		} else if strings.HasPrefix(req.RequestLine.RequestTarget, "/httpbin/stream") {
 			target := req.RequestLine.RequestTarget
-			res, err := http.Get("https://httpbin.org/" + target[len("/httpbin/stream"):])
+			res, err := http.Get("https://httpbin.org/" + target[len("/httpbin/"):]) // make request with stream length
 			if err != nil {
 				body = respond500()
 				status = response.StatusInternalServerError
@@ -82,8 +82,13 @@ func main() {
 					if err != nil {
 						break
 					}
-					w.WriteBody([]byte("0\r\n\r\n")) // zero length body
+
+					w.WriteBody([]byte(fmt.Sprintf("%x\r\n", n)))
+					w.WriteBody(data[:n])
+					w.WriteBody([]byte("\r\n"))
 				}
+				w.WriteBody([]byte("0\r\n\r\n")) // zero length body at the end
+				return
 			}
 		}
 		h.Replace("Content-Length", fmt.Sprintf("%d", len(body)))

--- a/internal/headers/headers.go
+++ b/internal/headers/headers.go
@@ -73,6 +73,10 @@ func (h *Headers) Replace(name, value string) {
 	h.headers[name] = value
 }
 
+func (h *Headers) Delete(name string) {
+	name = strings.ToLower(name)
+	delete(h.headers, name)
+}
 func (h *Headers) ForEach(cb func(n, v string)) {
 	for n, v := range h.headers {
 		cb(n, v)

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -90,3 +90,7 @@ func (w *Writer) WriteBody(p []byte) (int, error) {
 	// write header length
 	return n, nil
 }
+
+// INFO: chunked encoding is a sequence of 0xFF hex byte lengths \r\n followed by the specified amount of bytes as the payload
+func (w *Writer) WriteChunkedBody(p []byte) (int, error) {}
+func (w *Writer) WriteChunkedBodyDone() (int, error)     {}

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -58,7 +58,7 @@ func (w *Writer) WriteStatusLine(statusCode StatusCode) error {
 		return fmt.Errorf("unrecognized error code")
 	}
 
-	slog.Info("WritingStatusLine", "statusLine", statusLine)
+	slog.Info("WritingStatusLine\r\n", "statusLine", statusLine)
 	_, err := w.writer.Write(statusLine)
 	return err
 }
@@ -73,7 +73,7 @@ func (w *Writer) WriteHeaders(h headers.Headers) error {
 	})
 	b = fmt.Appendf(b, "\r\n")
 
-	slog.Info("WriteHeaders", "headers", b)
+	slog.Info("WriteHeaders\r\n", "headers", b)
 	w.writer.Write(b)
 
 	return err
@@ -81,7 +81,7 @@ func (w *Writer) WriteHeaders(h headers.Headers) error {
 
 // can write a custom body
 func (w *Writer) WriteBody(p []byte) (int, error) {
-	slog.Info("WriteBody", "body", p)
+	slog.Info("WriteBody\r\n", "body", p)
 	n, err := w.writer.Write(p)
 	if err != nil {
 		return 0, err
@@ -92,5 +92,9 @@ func (w *Writer) WriteBody(p []byte) (int, error) {
 }
 
 // INFO: chunked encoding is a sequence of 0xFF hex byte lengths \r\n followed by the specified amount of bytes as the payload
-func (w *Writer) WriteChunkedBody(p []byte) (int, error) {}
-func (w *Writer) WriteChunkedBodyDone() (int, error)     {}
+func (w *Writer) WriteChunkedBody(p []byte) (int, error) {
+	return 0, nil
+}
+func (w *Writer) WriteChunkedBodyDone() (int, error) {
+	return 0, nil
+}


### PR DESCRIPTION
This pull request introduces support for HTTP chunked transfer encoding, specifically for streaming responses from httpbin.org, and adds utility methods for header management and logging improvements. The most important changes are grouped below.

### Streaming and Chunked Transfer Encoding

* Added support for streaming requests to `/httpbin/stream*` endpoints by proxying the response from httpbin.org and manually handling chunked transfer encoding in `cmd/httpserver/main.go`. The server now streams the response in chunks, sets the appropriate headers, and writes each chunk according to the HTTP/1.1 specification.
* Added stub methods `WriteChunkedBody` and `WriteChunkedBodyDone` to `internal/response/response.go` for future extensibility in handling chunked body writes.

### Header Management

* Added a `Delete` method to the `Headers` type in `internal/headers/headers.go`, allowing for removal of headers such as `Content-Length` when using chunked transfer encoding.

### Logging Improvements

* Updated logging statements in `internal/response/response.go` to include a newline for improved readability when debugging response status lines, headers, and body writes. [[1]](diffhunk://#diff-dd08154977826c7fb2c75d407791bf298872771117fc42796f24733ea0b932aaL61-R61) [[2]](diffhunk://#diff-dd08154977826c7fb2c75d407791bf298872771117fc42796f24733ea0b932aaL76-R84)

These changes collectively enable the server to handle streaming endpoints with proper chunked encoding, improve header management, and enhance logging for debugging.mock request is forwarded to receive chunks and returns them in 32byte in the response